### PR TITLE
Basic Whitelist

### DIFF
--- a/GhostServer/main_cli.cpp
+++ b/GhostServer/main_cli.cpp
@@ -227,12 +227,11 @@ static void handle_cmd(char *line) {
         if (!strcmp(line, "whitelist")) {
             if (g_network->whitelist.size() == 0) {
                 puts("No players on whitelist");
-                return;
-            }
-
-            puts("Players on whitelist:");
-            for (auto& entry : g_network->whitelist) {
-                printf("  %s\n", entry.value.c_str());
+            } else {
+                puts("Players on whitelist:");
+                for (auto& entry : g_network->whitelist) {
+                    printf("  %s\n", entry.value.c_str());
+                }
             }
 
             if (g_network->whitelistEnabled)

--- a/GhostServer/main_cli.cpp
+++ b/GhostServer/main_cli.cpp
@@ -16,6 +16,8 @@ static enum {
     CMD_BAN,
     CMD_BAN_ID,
     CMD_SERVER_MSG,
+    CMD_WHITELIST_ADD,
+    CMD_WHITELIST_REMOVE,
 } g_current_cmd = CMD_NONE;
 
 static char *g_entered_pre;
@@ -59,6 +61,11 @@ static void handle_cmd(char *line) {
             puts("  accept_spectators   start accepting connections from spectators");
             puts("  refuse_spectators   stop accepting connections from spectators");
             puts("  server_msg          send all clients a message from the server");
+            puts("  whitelist_enable    enable whitelist");
+            puts("  whitelist_disable   disable whitelist");
+            puts("  whitelist_add       add player to whitelist");
+            puts("  whitelist_remove    remove player from whitelist");
+            puts("  whitelist           print out all players on whitelist");
             return;
         }
 
@@ -169,6 +176,45 @@ static void handle_cmd(char *line) {
             return;
         }
 
+        if (!strcmp(line, "whitelist_enable")) {
+            g_network->whitelistEnabled = true;
+            puts("Whitelist now enabled");
+            return;
+        }
+
+        if (!strcmp(line, "whitelist_disable")) {
+            g_network->whitelistEnabled = false;
+            puts("Whitelist now disabled");
+            return;
+        }
+
+        if (!strcmp(line, "whitelist_add")) {
+            g_current_cmd = CMD_WHITELIST_ADD;
+            fputs("Player to add: ", stdout);
+            fflush(stdout);
+            return;
+        }
+
+        if (!strcmp(line, "whitelist_remove")) {
+            g_current_cmd = CMD_WHITELIST_REMOVE;
+            fputs("Player to remove: ", stdout);
+            fflush(stdout);
+            return;
+        }
+
+        if (!strcmp(line, "whitelist")) {
+            if (g_network->whitelist.size() == 0) {
+                puts("No players on whitelist");
+                return;
+            }
+
+            puts("Players on whitelist:");
+            for (auto& entry : g_network->whitelist) {
+                printf("  %s\n", entry.c_str());
+            }
+            return;
+        }
+        
         printf("Unknown command: '%s'\n", line);
         return;
 
@@ -254,6 +300,18 @@ static void handle_cmd(char *line) {
     case CMD_SERVER_MSG:
         g_current_cmd = CMD_NONE;
         g_network->ServerMessage(line);
+        return;
+
+    case CMD_WHITELIST_ADD:
+        g_current_cmd = CMD_NONE;
+        g_network->whitelist.insert(line);
+        printf("Added player %s to whitelist\n", line);
+        return;
+
+    case CMD_WHITELIST_REMOVE:
+        g_current_cmd = CMD_NONE;
+        g_network->whitelist.erase(line);
+        printf("Removed player %s from whitelist\n", line);
         return;
     }
 }

--- a/GhostServer/networkmanager.cpp
+++ b/GhostServer/networkmanager.cpp
@@ -255,6 +255,14 @@ void NetworkManager::CheckConnection()
         return;
     }
 
+    if (whitelistEnabled) {
+        auto index = whitelist.find(name);
+        if (index == whitelist.end()) {
+            // Refuse connection, since the name was not found in the whitelist
+            return;
+        }
+    }
+
     client.ID = this->lastID++;
     client.IP = client.tcpSocket->getRemoteAddress();
     client.port = port;

--- a/GhostServer/networkmanager.cpp
+++ b/GhostServer/networkmanager.cpp
@@ -256,9 +256,9 @@ void NetworkManager::CheckConnection()
     }
 
     if (whitelistEnabled) {
-        auto index = whitelist.find(name);
-        if (index == whitelist.end()) {
-            // Refuse connection, since the name was not found in the whitelist
+        auto clientIp = client.tcpSocket->getRemoteAddress();
+        if (!IsOnWhitelist(name, clientIp)) {
+            // Refuse connection, since the player was not found in the whitelist
             return;
         }
     }
@@ -553,4 +553,22 @@ void NetworkManager::DoHeartbeats()
             }
         }
     }
+}
+
+bool NetworkManager::IsOnWhitelist(std::string name, sf::IpAddress IP) {
+    if (whitelist.empty())
+        return false;
+
+    auto index = std::find_if(whitelist.begin(), whitelist.end(), [&name, &IP](const WhitelistEntry& entry) {
+        switch (entry.type) {
+        case WhitelistEntryType::NAME:
+            return entry.value == name;
+        case WhitelistEntryType::IP:
+            return entry.value == IP.toString();
+        default:
+            return false;
+        }
+    });
+
+    return index != whitelist.end();
 }

--- a/GhostServer/networkmanager.cpp
+++ b/GhostServer/networkmanager.cpp
@@ -121,6 +121,18 @@ Client* NetworkManager::GetClientByID(sf::Uint32 ID)
     return nullptr;
 }
 
+Client* NetworkManager::GetClientByIP(std::string IP) {
+    sf::IpAddress clientIP(IP);
+
+    for (auto& client : this->clients) {
+        if (client.IP == clientIP) {
+            return &client;
+        }
+    }
+
+    return nullptr;
+}
+
 bool NetworkManager::StartServer(const int port)
 {
     if (this->udpSocket.bind(port) != sf::Socket::Done) {

--- a/GhostServer/networkmanager.h
+++ b/GhostServer/networkmanager.h
@@ -65,6 +65,20 @@ struct Client {
     bool spectator;
 };
 
+enum class WhitelistEntryType {
+    NAME,
+    IP,
+};
+
+struct WhitelistEntry {
+    WhitelistEntryType type;
+    std::string value;
+
+    bool operator<(const WhitelistEntry& rhs) const {
+        return value < rhs.value;
+    }
+};
+
 #ifdef GHOST_GUI
 class NetworkManager : public QObject
 {
@@ -102,7 +116,7 @@ public:
     bool acceptingSpectators = true;
 
     bool whitelistEnabled = true; // false
-    std::set<std::string> whitelist;
+    std::set<WhitelistEntry> whitelist;
 
     void ScheduleServerThread(std::function<void()> func);
 
@@ -123,6 +137,8 @@ public:
 
     void BanClientIP(Client &cl);
     void ServerMessage(const char *msg);
+
+    bool IsOnWhitelist(std::string name, sf::IpAddress IP);
 
 #ifdef GHOST_GUI
 signals:

--- a/GhostServer/networkmanager.h
+++ b/GhostServer/networkmanager.h
@@ -115,7 +115,7 @@ public:
     bool acceptingPlayers = true;
     bool acceptingSpectators = true;
 
-    bool whitelistEnabled = true; // false
+    bool whitelistEnabled = false;
     std::set<WhitelistEntry> whitelist;
 
     void ScheduleServerThread(std::function<void()> func);

--- a/GhostServer/networkmanager.h
+++ b/GhostServer/networkmanager.h
@@ -4,6 +4,7 @@
 #include <SFML/Network.hpp>
 
 #include <vector>
+#include <set>
 #include <mutex>
 #include <atomic>
 #include <thread>
@@ -99,6 +100,9 @@ public:
     std::vector<sf::IpAddress> bannedIps;
     bool acceptingPlayers = true;
     bool acceptingSpectators = true;
+
+    bool whitelistEnabled = true; // false
+    std::set<std::string> whitelist;
 
     void ScheduleServerThread(std::function<void()> func);
 

--- a/GhostServer/networkmanager.h
+++ b/GhostServer/networkmanager.h
@@ -121,6 +121,7 @@ public:
     void ScheduleServerThread(std::function<void()> func);
 
     Client* GetClientByID(sf::Uint32 ID);
+    Client* GetClientByIP(std::string IP);
 
     bool StartServer(const int port);
     void StopServer();


### PR DESCRIPTION
This adds a basic toggleable whitelist to the Ghost Server. You can currently add player names and IPs to the whitelist via the cli. 

Commands:
- `whitelist_[enable/disable]` - Enables / Disables the whitelist. Disabling the whitelist will not delete anything from the whitelist, so if you enable it again, everything will still be there. Furthermore, enabling the whitelist gives you the option to disconnect all currently connected players that are not on the whitelist.
- `whitelist_add_[name/ip]` - Add a player name or IP to the whitelist. The whitelist is stored as a set and thus duplicates are avoided.
- `whitelist_remove_[name/ip]` - Remove a player name or IP from the whitelist.
- `whitelist` - List all entries on the whitelist and if the whitelist is currently disabled or not.