### PR TITLE
Ability to register callbacks for when clients connect/disconnect

### DIFF
--- a/GhostServer/networkmanager.cpp
+++ b/GhostServer/networkmanager.cpp
@@ -235,6 +235,7 @@ void NetworkManager::DisconnectPlayer(Client& c, const char *reason)
     if (toErase != -1) {
         this->clients.erase(this->clients.begin() + toErase);
         UI_EVENT("client_change");
+        OnConnectedClientsChanged();
     }
 }
 
@@ -374,6 +375,7 @@ void NetworkManager::CheckConnection()
 
     UI_EVENT("client_change");
     GHOST_LOG("Connection: " + client.name + " (" + (client.spectator ? "spectator" : "player") + ") @ " + client.IP.toString() + ":" + std::to_string(client.port));
+    OnConnectedClientsChanged();
 
     this->clients.push_back(std::move(client));
 }
@@ -657,4 +659,15 @@ bool NetworkManager::IsOnWhitelist(std::string name, sf::IpAddress IP) {
     });
 
     return index != whitelist.end();
+}
+
+void NetworkManager::OnConnectedClientsChanged() {
+    for (auto const& [id, callback] : connectedClientsChangedCallbacks) {
+        callback();
+    }
+}
+
+int NetworkManager::RegisterConnectedClientsChangedCallback(std::function<void()> callback) {
+    connectedClientsChangedCallbacks.insert({connectedClientsChangedCallbackId++, callback});
+    return connectedClientsChangedCallbackId - 1;
 }

--- a/GhostServer/networkmanager.cpp
+++ b/GhostServer/networkmanager.cpp
@@ -23,11 +23,9 @@ static void file_log(std::string str) {
 #ifdef GHOST_GUI
 # include <QVector>
 # define GHOST_LOG(x) (file_log(x), emit this->OnNewEvent(QString::fromStdString(x)))
-# define UI_EVENT(x) (emit this->UIEvent(x))
 #else
 # include <stdio.h>
 # define GHOST_LOG(x) (file_log(x), printf("[LOG] %s\n", std::string(x).c_str()))
-# define UI_EVENT(x) ((void)0)
 #endif
 
 #define HEARTBEAT_RATE 5000
@@ -235,7 +233,6 @@ void NetworkManager::DisconnectPlayer(Client& c, const char *reason)
     if (toErase != -1) {
         this->clients.erase(this->clients.begin() + toErase);
         UI_EVENT("client_change");
-        OnConnectedClientsChanged();
     }
 }
 
@@ -373,11 +370,11 @@ void NetworkManager::CheckConnection()
         c.tcpSocket->send(packet_notify_all);
     }
 
-    UI_EVENT("client_change");
     GHOST_LOG("Connection: " + client.name + " (" + (client.spectator ? "spectator" : "player") + ") @ " + client.IP.toString() + ":" + std::to_string(client.port));
-    OnConnectedClientsChanged();
 
     this->clients.push_back(std::move(client));
+
+    UI_EVENT("client_change");
 }
 
 void NetworkManager::ReceiveUDPUpdates(std::vector<std::tuple<sf::Packet, sf::IpAddress, unsigned short>>& buffer)
@@ -661,13 +658,18 @@ bool NetworkManager::IsOnWhitelist(std::string name, sf::IpAddress IP) {
     return index != whitelist.end();
 }
 
-void NetworkManager::OnConnectedClientsChanged() {
-    for (auto const& [id, callback] : connectedClientsChangedCallbacks) {
-        callback();
+
+void NetworkManager::UI_EVENT(std::string event) {
+    for (auto item : uiEventCallbacks) {
+        auto [type, callback] = item.second;
+        if (type == event) callback();
     }
+#ifdef GHOST_GUI
+    emit this->UIEvent(event);
+#endif
 }
 
-int NetworkManager::RegisterConnectedClientsChangedCallback(std::function<void()> callback) {
-    connectedClientsChangedCallbacks.insert({connectedClientsChangedCallbackId++, callback});
-    return connectedClientsChangedCallbackId - 1;
+int NetworkManager::RegisterEventCallback(std::string type, std::function<void()> callback) {
+    uiEventCallbacks.insert({uiEventCallbackId++, {type, callback}});
+    return uiEventCallbackId - 1;
 }

--- a/GhostServer/networkmanager.h
+++ b/GhostServer/networkmanager.h
@@ -2,13 +2,14 @@
 
 #include <SFML/Network.hpp>
 
-#include <vector>
-#include <set>
-#include <mutex>
 #include <atomic>
-#include <thread>
 #include <cstdint>
 #include <functional>
+#include <map>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <vector>
 
 #ifdef GHOST_GUI
 #include <QObject>
@@ -104,7 +105,12 @@ private:
 
     sf::Clock clock;
 
+    std::map<int, std::function<void()>> connectedClientsChangedCallbacks;
+    int connectedClientsChangedCallbackId = 1;
+
     void DoHeartbeats();
+
+    void OnConnectedClientsChanged();
 
 public:
     NetworkManager(const char *logfile = "ghost_log.log");
@@ -144,11 +150,12 @@ public:
 
     bool IsOnWhitelist(std::string name, sf::IpAddress IP);
 
+    int RegisterConnectedClientsChangedCallback(std::function<void()> callback);
+    void UnregisterConnectedClientsChangedCallback(int id) { connectedClientsChangedCallbacks.erase(id); }
+
 #ifdef GHOST_GUI
 signals:
     void OnNewEvent(QString log);
     void UIEvent(std::string event);
 #endif
-
-
 };

--- a/GhostServer/networkmanager.h
+++ b/GhostServer/networkmanager.h
@@ -105,12 +105,10 @@ private:
 
     sf::Clock clock;
 
-    std::map<int, std::function<void()>> connectedClientsChangedCallbacks;
-    int connectedClientsChangedCallbackId = 1;
+    std::map<int, std::tuple<std::string, std::function<void()>>> uiEventCallbacks;
+    int uiEventCallbackId = 1;
 
     void DoHeartbeats();
-
-    void OnConnectedClientsChanged();
 
 public:
     NetworkManager(const char *logfile = "ghost_log.log");
@@ -150,8 +148,9 @@ public:
 
     bool IsOnWhitelist(std::string name, sf::IpAddress IP);
 
-    int RegisterConnectedClientsChangedCallback(std::function<void()> callback);
-    void UnregisterConnectedClientsChangedCallback(int id) { connectedClientsChangedCallbacks.erase(id); }
+    void UI_EVENT(std::string event);
+    int RegisterEventCallback(std::string type, std::function<void()> callback);
+    void UnregisterEventCallback(int id) { uiEventCallbacks.erase(id); }
 
 #ifdef GHOST_GUI
 signals:


### PR DESCRIPTION
This adds a simple mechanism for users of the `NetworkManager` to have a callback called when a client connects or disconnects.

This is in preparation for a feature in [Portal2-GhostServer-Hoster](https://github.com/p2sr/Portal2-GhostServer-Hoster).